### PR TITLE
Minimum 1 damage rules

### DIFF
--- a/pathfinder2e_stats/damage.py
+++ b/pathfinder2e_stats/damage.py
@@ -142,6 +142,11 @@ def _roll_damage(
             else:
                 assert d.multiplier == 1
 
+            # Halved damage is rounded down, but can't be reduced below 1.
+            # If the combined penalties on an attack would reduce the damage to 0 or
+            # below, you still deal 1 damage.
+            r = cast(DataArray, np.maximum(1, r))
+
             damage_rolls.append(r)
 
         r = xarray.concat(damage_rolls, dim="damage_type", join="outer", fill_value=0)

--- a/pathfinder2e_stats/damage_spec.py
+++ b/pathfinder2e_stats/damage_spec.py
@@ -132,7 +132,7 @@ class Damage:
                 # Sum flat bonus to dice
                 out[-2:] = [out[-2].copy(bonus=out[-2].bonus + out[-1].bonus)]
 
-        return [o for o in out if bool(o)]
+        return out
 
     def copy(self, **kwargs: Any) -> Damage:
         kwargs2 = {k: getattr(self, k) for k in self.__annotations__}
@@ -222,10 +222,6 @@ class Damage:
         d = self._auto_two_hands()
         return DamageList([d]) + other
 
-    def __bool__(self) -> bool:
-        """Return True if rolled damage can be more than zero; False otherwise."""
-        return self.dice * (self.fatal or self.faces) + self.bonus + self.deadly > 0
-
 
 class DamageList(UserList[Damage]):
     @property
@@ -266,7 +262,6 @@ class ExpandedDamage(UserDict[DoS, list[Damage]]):
         else:
             data = {DoS(k): list(v) for k, v in data.items()}
 
-        data = {k: [vi for vi in v if bool(vi)] for k, v in data.items()}
         data = {k: v for k, v in data.items() if v}
         self.data = dict(sorted(data.items(), reverse=True))  # success > failure
 

--- a/pathfinder2e_stats/tests/test_damage_spec.py
+++ b/pathfinder2e_stats/tests/test_damage_spec.py
@@ -121,6 +121,9 @@ def test_damage_type_simplify():
         Damage("piercing", 1, 8, multiplier=2),
         Damage("piercing", 1, 8),
         Damage("piercing", 3, 6, 3),
+        # If the combined penalties on an attack would reduce the
+        # damage to 0 or below, you still deal 1 damage.
+        Damage("force", 1, 6, -6),
         Damage("fire", 1, 4, persistent=True),
         Damage("fire", 0, 0, 1, splash=True),
     ]
@@ -369,37 +372,6 @@ def test_expanded_damage_filter():
         }
     with pytest.raises(ValueError, match="misspelled"):
         d.filter("persistent", "misspelled")
-
-
-def test_damage_bool():
-    assert bool(Damage("fire", 0, 0, 1)) is True
-    assert bool(Damage("fire", 0, 0, 0)) is False
-    assert bool(Damage("fire", 0, 0, -1)) is False
-
-    assert bool(Damage("fire", 2, 6, -11)) is True
-    assert bool(Damage("fire", 2, 6, -12)) is False
-    assert bool(Damage("fire", 2, 6, -13)) is False
-
-    assert bool(Damage("fire", 1, 6, -6)) is False
-    assert bool(Damage("fire", 1, 6, -6, deadly=8)) is True
-    assert bool(Damage("fire", 1, 6, -14, deadly=8)) is False
-    assert bool(Damage("fire", 1, 6, -15, deadly=8)) is False
-
-    assert bool(Damage("fire", 2, 6, -15, fatal=8)) is True
-    assert bool(Damage("fire", 2, 6, -16, fatal=8)) is False
-    assert bool(Damage("fire", 2, 6, -17, fatal=8)) is False
-
-
-def test_no_damage():
-    d = Damage("slashing", 1, 6, -6)
-    assert d.expand() == {}
-
-    d = Damage("slashing", 1, 6, -6) + Damage("fire", 0, 0, 0)
-    assert d == []
-    assert d.expand() == {}
-
-    d = ExpandedDamage({1: [Damage("slashing", 1, 6, -6)]})
-    assert d == {}
 
 
 def test_reduce_die():


### PR DESCRIPTION
- Halving damage can't reduce it below 1
- If the combined penalties on an attack would reduce the damage to 0 or below, you still deal 1 damage.

This PR is partially incorrect, rules wise. See follow-up : https://github.com/crusaderky/pathfinder2e_stats/issues/56